### PR TITLE
Fix the change secret not send event issue

### DIFF
--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -207,7 +207,7 @@ func (c *FSRestClient) retryDo(url string, jsonStr string) ([]byte, error) {
 
 	retryCnt := 2
 	for i := 0; i < retryCnt-1; i++ {
-		if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
+		if len(body) > 0 && statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
 			return body, err
 		}
 


### PR DESCRIPTION
After change the FS password, use the old token to access FS api still get response code 200, but the body is empty. The API behavior is abnormal..
The code check the response code is 200 will pass, add the body check.