### PR TITLE
Add codespell and commitlint actions, enable gosec linter

### DIFF
--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -1,0 +1,85 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "body-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "body-empty": [
+            1,
+            "never"
+        ],
+        "body-full-stop": [
+            1,
+            "always",
+            "."
+        ],
+        "body-leading-blank": [
+            2,
+            "always"
+        ],
+        "body-max-line-length": [
+            2,
+            "always",
+            72
+        ],
+        "footer-leading-blank": [
+            2,
+            "always"
+        ],
+        "header-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "header-full-stop": [
+            2,
+            "never",
+            "."
+        ],
+        "header-max-length": [
+            2,
+            "always",
+            72
+        ],
+        "signed-off-by": [
+            2,
+            "always"
+        ],
+        "subject-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "subject-empty": [
+            2,
+            "never"
+        ],
+        "type-case": [
+            0,
+            "always",
+            "lower-case"
+        ],
+        "type-empty": [
+            2,
+            "never"
+        ],
+        "type-enum": [
+            2,
+            "always",
+            [
+                "action",
+                "api",
+                "bundle",
+                "ci",
+                "controllers",
+                "docs",
+                "godeps",
+                "test"
+            ]
+        ]
+    }
+}

--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -77,6 +77,7 @@
                 "ci",
                 "controllers",
                 "docs",
+                "fix",
                 "godeps",
                 "test"
             ]

--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -22,6 +22,22 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: codespell
+      uses: codespell-project/actions-codespell@master
+      with:
+        check_filenames: true
+        check_hidden: true
+
+    - name: run commitlint
+      uses: wagoid/commitlint-github-action@v3
+      with:
+        configFile: './.github/workflows/conf/commitlintrc.json'
+        helpURL: |
+          Some helpful links
+          Naming Conventions -> https://commitlint.js.org/#/concepts-commit-conventions
+          Rules -> https://commitlint.js.org/#/reference-rules
+          How to Write a Good Git Commit Message -> https://chris.beams.io/posts/git-commit
+
     - name: golangci-lint
       run: |
         make lint

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ deps:
 
 .PHONY: lint
 lint: deps
-	golangci-lint run --timeout=6m    # Run `make lint-fix` may help to fix lint issues.
+	golangci-lint run -E gosec --timeout=6m    # Run `make lint-fix` may help to fix lint issues.
 
 .PHONY: lint-fix
 lint-fix: deps	
@@ -55,4 +55,3 @@ add-copyright:
 
 check-copyright:
 	hack/check-copyright.sh
-	


### PR DESCRIPTION
action: add codespell and commitlint actions for precheck
makefile: enable gosec linter for golangci-lint

Please help to review, thanks.

Signed-off-by: Bo Liu lbseraph@gmail.com